### PR TITLE
Update .gitignore no more json credentials allowed.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,5 @@
 .venv*
+credentials.json
+token.json
+
+


### PR DESCRIPTION
It is not clear to me exactly how authentication should work. 
But no matter how it works, the json credential information should not be accidentally uploaded to github.